### PR TITLE
Handle optional scope and refresh token decoding

### DIFF
--- a/Spotify/Models/SpotifyToken.swift
+++ b/Spotify/Models/SpotifyToken.swift
@@ -34,8 +34,8 @@ struct SpotifyToken: Codable {
         self.expires_in = try container.decode(Int.self, forKey: .expires_in)
         // If createdAt is missing, default to now
         self.createdAt = (try? container.decode(Date.self, forKey: .createdAt)) ?? Date()
-        self.scope = try container.decode(String.self, forKey: .scope)
-        self.refresh_token = try container.decode(String.self, forKey: .refresh_token)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.refresh_token = try container.decodeIfPresent(String.self, forKey: .refresh_token)
     }
     
     static func asBase64Credentials(s: String) -> String  {


### PR DESCRIPTION
## Summary
- use `decodeIfPresent` for `scope` and `refresh_token` to allow missing fields

## Testing
- `swift test` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_e_68a46501c70883259f75e074fdef64c5