### PR TITLE
Explicit Edge.Set for horizontal padding

### DIFF
--- a/amtransfer/Spotify/Views/LoginView.swift
+++ b/amtransfer/Spotify/Views/LoginView.swift
@@ -24,7 +24,8 @@ struct LoginView: View {
                 .textFieldStyle(.roundedBorder)
                 .autocapitalization(.none)
                 .disableAutocorrection(true)
-                .padding(.horizontal)
+                // Explicitly specify the Edge.Set to avoid contextual base inference errors in Xcode
+                .padding(Edge.Set.horizontal)
             
             Button("3. Complete Login") {
                 Task {


### PR DESCRIPTION
## Summary
- Avoid contextual inference errors in LoginView by explicitly using `Edge.Set.horizontal`

## Testing
- `swift test` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_e_68a6c868fd888325b48a1efd648a2711