### PR TITLE
Enable scalable ContentView preview

### DIFF
--- a/amtransfer/ContentView.swift
+++ b/amtransfer/ContentView.swift
@@ -55,3 +55,11 @@ struct ContentView: View {
         }
     }
 }
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+            .previewLayout(.sizeThatFits)
+            .frame(minWidth: 400, minHeight: 300)
+    }
+}


### PR DESCRIPTION
## Summary
- add preview provider for ContentView
- size preview with `.sizeThatFits` and a minimum frame so the app window is resizable without overfilling the pane

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f052621083258b362388a58940dd