### PR TITLE
Load Spotify credentials from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SPOTIFY_CLIENT_ID=your_client_id
+SPOTIFY_CLIENT_SECRET=your_client_secret
+SPOTIFY_REDIRECT_URI=https://your.redirect.uri/callback

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ fastlane/test_output
 
 # Unix
 .DS_Store
+.env

--- a/amtransfer/Spotify/SpotifyAdapter.swift
+++ b/amtransfer/Spotify/SpotifyAdapter.swift
@@ -9,15 +9,18 @@ class SpotifyAdapter: ObservableObject {
     @Published var tokenId: String = "unset"
     @Published var topTracks: [SpotifyTrack] = []
     
-    private let clientID = "442144c176c44965a2c05859fc00e5e6"
-    private let clientSecret = "face180305184bd6bc692d932d8756c0"
-    private let redirectURI = "https://cruditech.com/callback"
+    private let clientID = ProcessInfo.processInfo.environment["SPOTIFY_CLIENT_ID"] ?? ""
+    private let clientSecret = ProcessInfo.processInfo.environment["SPOTIFY_CLIENT_SECRET"] ?? ""
+    private let redirectURI = ProcessInfo.processInfo.environment["SPOTIFY_REDIRECT_URI"] ?? ""
     
     private let tokenKey = "spotify-token"
     private let profileKey = "spotify-user-profile"
     
     init() {
         print("SpotifyAdapter initialized.")
+        if clientID.isEmpty || clientSecret.isEmpty || redirectURI.isEmpty {
+            print("⚠️ Spotify credentials are not fully set in environment variables.")
+        }
     }
     
     func setup() async {


### PR DESCRIPTION
## Summary
- Read Spotify client ID, client secret, and redirect URI from environment variables
- Provide `.env.example` and ignore `.env` for local secret configuration

## Testing
- ❌ `swift test` *(no Package.swift found)*
- ⚠️ `xcodebuild test -scheme amtransfer -destination 'platform=iOS Simulator,name=iPhone 14'` *(command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a85ee371e08325a2378c61522ee438