### PR TITLE
Load Spotify credentials from Secrets plist

### DIFF
--- a/amtransfer.xcodeproj/project.pbxproj
+++ b/amtransfer.xcodeproj/project.pbxproj
@@ -10,9 +10,7 @@
 		EC7978A02E596FFA00B49BF9 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = EC79789F2E596FFA00B49BF9 /* .gitignore */; };
 		EC7978A12E596FFA00B49BF9 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = EC79789F2E596FFA00B49BF9 /* .gitignore */; };
 		EC7978A22E596FFA00B49BF9 /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = EC79789F2E596FFA00B49BF9 /* .gitignore */; };
-		ECA8D0742E58A66300BB0990 /* amtransfer/Config/Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = ECA8D0732E58A66300BB0990 /* amtransfer/Config/Secrets.plist */; };
-		ECA8D0752E58A66300BB0990 /* amtransfer/Config/Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = ECA8D0732E58A66300BB0990 /* amtransfer/Config/Secrets.plist */; };
-		ECA8D0762E58A66300BB0990 /* amtransfer/Config/Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = ECA8D0732E58A66300BB0990 /* amtransfer/Config/Secrets.plist */; };
+                ECA8D0742E58A66300BB0990 /* amtransfer/Config/Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = ECA8D0732E58A66300BB0990 /* amtransfer/Config/Secrets.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -230,24 +228,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		EC1E83642E54C25B00E4AE72 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EC7978A02E596FFA00B49BF9 /* .gitignore in Resources */,
-				ECA8D0752E58A66300BB0990 /* amtransfer/Config/Secrets.plist in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EC1E836E2E54C25B00E4AE72 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				EC7978A12E596FFA00B49BF9 /* .gitignore in Resources */,
-				ECA8D0762E58A66300BB0990 /* amtransfer/Config/Secrets.plist in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                EC1E83642E54C25B00E4AE72 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                EC7978A02E596FFA00B49BF9 /* .gitignore in Resources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
+                EC1E836E2E54C25B00E4AE72 /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                EC7978A12E596FFA00B49BF9 /* .gitignore in Resources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */

--- a/amtransfer/Spotify/SpotifyAdapter.swift
+++ b/amtransfer/Spotify/SpotifyAdapter.swift
@@ -8,10 +8,21 @@ class SpotifyAdapter: ObservableObject {
     @Published var userProfile: SpotifyUserProfile?
     @Published var tokenId: String = "unset"
     @Published var topTracks: [SpotifyTrack] = []
-    
-    private let clientID = Bundle.main.object(forInfoDictionaryKey: "SPOTIFY_CLIENT_ID") as? String ?? ""
-    private let clientSecret = Bundle.main.object(forInfoDictionaryKey: "SPOTIFY_CLIENT_SECRET") as? String ?? ""
-    private let redirectURI = Bundle.main.object(forInfoDictionaryKey: "SPOTIFY_REDIRECT_URI") as? String ?? ""
+
+    private static func loadSecrets() -> [String: Any] {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let dict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+            return [:]
+        }
+        return dict
+    }
+
+    private static let secrets = loadSecrets()
+
+    private let clientID = SpotifyAdapter.secrets["SPOTIFY_CLIENT_ID"] as? String ?? ""
+    private let clientSecret = SpotifyAdapter.secrets["SPOTIFY_CLIENT_SECRET"] as? String ?? ""
+    private let redirectURI = SpotifyAdapter.secrets["SPOTIFY_REDIRECT_URI"] as? String ?? ""
     
     private let tokenKey = "spotify-token"
     private let profileKey = "spotify-user-profile"
@@ -31,7 +42,7 @@ class SpotifyAdapter: ObservableObject {
     init() {
         print("SpotifyAdapter initialized.")
         if clientID.isEmpty || clientSecret.isEmpty || redirectURI.isEmpty {
-            print("⚠️ Spotify credentials are not fully set in environment variables.")
+            print("⚠️ Spotify credentials are not fully set in Secrets.plist.")
         }
     }
     


### PR DESCRIPTION
## Summary
- load Spotify secrets from bundled Secrets.plist
- switch SpotifyAdapter to read credentials from loaded secrets dictionary
- include Secrets.plist only in the app target's resources

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9982b18f48325a82ea6150f7315d4