### PR TITLE
Add media library view combining local and Spotify playlists

### DIFF
--- a/amtransfer/MediaLibraryView.swift
+++ b/amtransfer/MediaLibraryView.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// A simple library view combining existing media and selected Spotify playlists.
+struct MediaLibraryView: View {
+    /// Mock existing library items provided by the app.
+    var existingItems: [String]
+
+    /// Spotify playlists chosen in `LoggedInView`.
+    var playlists: [SpotifyPlaylist]
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section("Your Library") {
+                    ForEach(existingItems, id: \.self) { item in
+                        Text(item)
+                    }
+                }
+
+                if !playlists.isEmpty {
+                    Section("Spotify Playlists") {
+                        ForEach(playlists) { playlist in
+                            Text(playlist.name)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Library")
+        }
+    }
+}
+
+#Preview {
+    MediaLibraryView(
+        existingItems: ["Local Album", "Downloaded Track"],
+        playlists: [
+            .init(id: "1", name: "Mock Playlist")
+        ]
+    )
+}

--- a/amtransfer/Spotify/Views/LoggedInView.swift
+++ b/amtransfer/Spotify/Views/LoggedInView.swift
@@ -3,9 +3,12 @@ import SwiftUI
 struct LoggedInView: View {
     @ObservedObject var spotify: SpotifyAdapter
     @State private var selectedPlaylists: Set<String> = []
+    /// Mock items representing a user's existing library content.
+    private let mockLibraryItems = ["Saved Track", "Downloaded Album"]
 
     var body: some View {
-        NavigationStack {
+        let selectedPlaylistObjects = spotify.playlists.filter { selectedPlaylists.contains($0.id) }
+        return NavigationStack {
             VStack {
                 if let profile = spotify.userProfile {
                     Text("Welcome, \(profile.display_name)!")
@@ -58,6 +61,14 @@ struct LoggedInView: View {
                         }
                     }
                 }
+
+                NavigationLink("Library") {
+                    MediaLibraryView(
+                        existingItems: mockLibraryItems,
+                        playlists: selectedPlaylistObjects
+                    )
+                }
+                .padding(.vertical)
 
                 Button("Logout", role: .destructive) {
                     spotify.logout()


### PR DESCRIPTION
## Summary
- add `MediaLibraryView` to display existing library items with Spotify playlists
- link `LoggedInView` to new library screen

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild test -project amtransfer.xcodeproj -scheme amtransfer -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dc956c8c8325b705562dbdbbade6