### PR TITLE
Add example Spotify secrets plist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ## Spotify API Configuration
 
-The app expects Spotify credentials bundled in `Config/Secrets.plist`.
-Provide values for the following keys:
+A template file is provided at `amtransfer/Config/Secrets.example.plist`.
+Copy it to `amtransfer/Config/Secrets.plist` and update the placeholders
+with your own Spotify credentials. The app expects this `Secrets.plist`
+to be bundled in the app at build time. Provide values for the following keys:
 
 - `SPOTIFY_CLIENT_ID`
 - `SPOTIFY_CLIENT_SECRET`

--- a/amtransfer/Config/Secrets.example.plist
+++ b/amtransfer/Config/Secrets.example.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>SPOTIFY_CLIENT_ID</key>
+    <string>your_client_id_here</string>
+    <key>SPOTIFY_CLIENT_SECRET</key>
+    <string>your_client_secret_here</string>
+    <key>SPOTIFY_REDIRECT_URI</key>
+    <string>your_redirect_uri_here</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add example `Secrets` plist template for Spotify credentials
- document how to copy and use `Secrets.example.plist`

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68abe083e7b48325a04264616793034d