### PR TITLE
Add Apple Music data models

### DIFF
--- a/amtransfer/AM/Models/AMArtist.swift
+++ b/amtransfer/AM/Models/AMArtist.swift
@@ -1,0 +1,3 @@
+struct AMArtist: Codable, Hashable {
+    let name: String
+}

--- a/amtransfer/AM/Models/AMPlaylist.swift
+++ b/amtransfer/AM/Models/AMPlaylist.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct AMPlaylist: Codable, Identifiable, Hashable {
+    let id: String
+    let name: String
+}
+
+struct AMPlaylistsResponse: Codable {
+    let data: [AMPlaylist]
+}
+
+struct AMPlaylistTracksResponse: Codable {
+    let data: [AMTrack]
+}

--- a/amtransfer/AM/Models/AMToken.swift
+++ b/amtransfer/AM/Models/AMToken.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct AMToken: Codable {
+    let token: String
+    let tokenType: String
+    let expiresIn: Int
+    let createdAt: Date
+    let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case createdAt
+        case refreshToken = "refresh_token"
+    }
+
+    init(token: String, tokenType: String, expiresIn: Int, refreshToken: String? = nil) {
+        self.token = token
+        self.tokenType = tokenType
+        self.expiresIn = expiresIn
+        self.createdAt = Date()
+        self.refreshToken = refreshToken
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.token = try container.decode(String.self, forKey: .token)
+        self.tokenType = try container.decode(String.self, forKey: .tokenType)
+        self.expiresIn = try container.decode(Int.self, forKey: .expiresIn)
+        self.createdAt = (try? container.decode(Date.self, forKey: .createdAt)) ?? Date()
+        self.refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+    }
+
+    func isExpired() -> Bool {
+        let expiresAt = createdAt.addingTimeInterval(TimeInterval(expiresIn))
+        return Date() > expiresAt
+    }
+}

--- a/amtransfer/AM/Models/AMTrack.swift
+++ b/amtransfer/AM/Models/AMTrack.swift
@@ -1,0 +1,9 @@
+struct AMTrack: Codable, Hashable, Identifiable {
+    let id: String
+    let name: String
+    let artists: [AMArtist]
+
+    var artistNames: String {
+        artists.map { $0.name }.joined(separator: ", ")
+    }
+}

--- a/amtransfer/AM/Models/AMTrackResponse.swift
+++ b/amtransfer/AM/Models/AMTrackResponse.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+// Models for the top songs endpoint
+struct TopSongsResponse: Codable {
+    let data: [AMTrack]
+}

--- a/amtransfer/AM/Models/AMUserProfile.swift
+++ b/amtransfer/AM/Models/AMUserProfile.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+// A simple struct to decode the /me endpoint response
+struct AMUserProfile: Codable, Identifiable {
+    let id: String
+    let name: String
+}

--- a/amtransferTests/AMTests.swift
+++ b/amtransferTests/AMTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import amtransfer
+
+struct AMTests {
+    @Test func tokenExpiration() async throws {
+        let token = AMToken(token: "abc", tokenType: "bearer", expiresIn: 1)
+        #expect(!token.isExpired())
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        #expect(token.isExpired())
+    }
+
+    @Test func trackArtistNames() throws {
+        let track = AMTrack(id: "1", name: "Song", artists: [AMArtist(name: "Artist 1"), AMArtist(name: "Artist 2")])
+        #expect(track.artistNames == "Artist 1, Artist 2")
+    }
+
+    @Test func decodeTopSongsResponse() throws {
+        let json = """
+        {"data":[{"id":"1","name":"Song","artists":[{"name":"Artist"}]}]}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(TopSongsResponse.self, from: json)
+        #expect(response.data.count == 1)
+        #expect(response.data[0].name == "Song")
+    }
+
+    @Test func decodePlaylistsResponse() throws {
+        let json = """
+        {"data":[{"id":"1","name":"My Playlist"}]}
+        """.data(using: .utf8)!
+        let response = try JSONDecoder().decode(AMPlaylistsResponse.self, from: json)
+        #expect(response.data.count == 1)
+        #expect(response.data[0].id == "1")
+    }
+}


### PR DESCRIPTION
## Summary
- add Apple Music model structs (artist, track, playlist, user profile, token, top songs response) under AM/Models
- add unit tests for Apple Music token expiration, track artist names, and decoding of top songs and playlist responses

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -project amtransfer.xcodeproj -scheme amtransfer -destination 'platform=iOS Simulator,name=iPhone 15'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68ac430873508325bca94ef9869131c5