### PR TITLE
Unify back navigation with reusable button view

### DIFF
--- a/amtransfer/BackButton.swift
+++ b/amtransfer/BackButton.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/// A reusable back button with a leading chevron and "Back" label.
+///
+/// This view dismisses the current presentation when tapped and can be
+/// reused across screens that require a custom back navigation button.
+struct BackButton: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Button(action: { dismiss() }) {
+            Label("Back", systemImage: "chevron.left")
+        }
+    }
+}
+

--- a/amtransfer/Spotify/Views/LibraryView.swift
+++ b/amtransfer/Spotify/Views/LibraryView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct LibraryView: View {
-    @Environment(\.dismiss) private var dismiss
 
     /// Mock playlists representing existing user content.
     private let mockPlaylists = [
@@ -33,9 +32,10 @@ struct LibraryView: View {
         }
         .padding(.top, 8)
         .navigationTitle("Library")
+        .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigation) {
-                Button("Back") { dismiss() }
+                BackButton()
             }
         }
     }

--- a/amtransfer/Spotify/Views/PlaylistDetailView.swift
+++ b/amtransfer/Spotify/Views/PlaylistDetailView.swift
@@ -4,7 +4,6 @@ struct PlaylistDetailView: View {
     @ObservedObject var spotify: SpotifyAdapter
     let playlist: SpotifyPlaylist
     @State private var tracks: [SpotifyTrack] = []
-    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         List {
@@ -26,9 +25,7 @@ struct PlaylistDetailView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigation) {
-                Button(action: { dismiss() }) {
-                    Label("Back", systemImage: "chevron.left")
-                }
+                BackButton()
             }
         }
         .task {


### PR DESCRIPTION
## Summary
- add reusable `BackButton` SwiftUI view with chevron and "Back" label
- update Library and Playlist detail screens to use shared `BackButton`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac447abae48325a11e741ac063345b