### PR TITLE
refactor: move media player library into AM module

### DIFF
--- a/amtransfer/AM/Views/AMLibraryView.swift
+++ b/amtransfer/AM/Views/AMLibraryView.swift
@@ -1,15 +1,15 @@
 import SwiftUI
 
-struct LibraryView: View {
+struct AMLibraryView: View {
 
     /// Mock playlists representing existing user content.
     private let mockPlaylists = [
-        SpotifyPlaylist(id: "m1", name: "Favourites"),
-        SpotifyPlaylist(id: "m2", name: "Road Trip")
+        AMPlaylist(id: "m1", name: "Favourites"),
+        AMPlaylist(id: "m2", name: "Road Trip")
     ]
 
     /// Playlists selected from the Spotify logged in view.
-    let selectedPlaylists: [SpotifyPlaylist]
+    let selectedPlaylists: [AMPlaylist]
 
     var body: some View {
         List {
@@ -19,7 +19,7 @@ struct LibraryView: View {
                 }
             }
 
-            Section("Selected Spotify Playlists") {
+            Section("Selected Playlists") {
                 if selectedPlaylists.isEmpty {
                     Text("No playlists selected")
                         .foregroundStyle(.secondary)
@@ -43,9 +43,9 @@ struct LibraryView: View {
 
 #Preview {
     NavigationStack {
-        LibraryView(selectedPlaylists: [
-            SpotifyPlaylist(id: "1", name: "Chill Vibes"),
-            SpotifyPlaylist(id: "2", name: "Workout Mix")
+        AMLibraryView(selectedPlaylists: [
+            AMPlaylist(id: "1", name: "Chill Vibes"),
+            AMPlaylist(id: "2", name: "Workout Mix")
         ])
     }
 }

--- a/amtransfer/Spotify/Views/LoggedInView.swift
+++ b/amtransfer/Spotify/Views/LoggedInView.swift
@@ -64,7 +64,11 @@ struct LoggedInView: View {
                 }
 
                 NavigationLink("Open Library") {
-                    LibraryView(selectedPlaylists: selectedPlaylistObjects)
+                    AMLibraryView(
+                        selectedPlaylists: selectedPlaylistObjects.map {
+                            AMPlaylist(id: $0.id, name: $0.name)
+                        }
+                    )
                 }
                 .padding(.vertical)
 


### PR DESCRIPTION
## Summary
- move LibraryView into dedicated AM module
- convert library view to use AM models and prefix
- keep selected playlists as Spotify models and convert to AM models when opening library

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68ac49cf02c883259525ec9792582116