### PR TITLE
Fetch Apple Music playlists

### DIFF
--- a/amtransfer/AM/AMAdapter.swift
+++ b/amtransfer/AM/AMAdapter.swift
@@ -1,0 +1,68 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+class AMAdapter: ObservableObject {
+    @Published var token: AMToken?
+    @Published var playlists: [AMPlaylist] = []
+
+    private static func loadSecrets() -> [String: Any] {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let dict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+            return [:]
+        }
+        return dict
+    }
+
+    private static let secrets = loadSecrets()
+    private let developerToken = AMAdapter.secrets["APPLE_DEVELOPER_TOKEN"] as? String ?? ""
+
+    private let tokenKey = "apple-music-user-token"
+
+    private let urlSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.waitsForConnectivity = true
+        return URLSession(configuration: configuration)
+    }()
+
+    init() {
+        if developerToken.isEmpty {
+            print("⚠️ Apple Music developer token not set in Secrets.plist")
+        }
+        if let storedToken: AMToken = KeychainHelper.standard.load(for: tokenKey) {
+            self.token = storedToken
+        }
+    }
+
+    func setup() async {
+        guard token != nil else {
+            print("No Apple Music user token available")
+            return
+        }
+        await fetchUserPlaylists()
+    }
+
+    func updateToken(_ newToken: AMToken) {
+        self.token = newToken
+        KeychainHelper.standard.save(newToken, for: tokenKey)
+    }
+
+    func fetchUserPlaylists() async {
+        guard let token = token else { return }
+
+        do {
+            let url = URL(string: "https://api.music.apple.com/v1/me/library/playlists")!
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
+            request.setValue(token.token, forHTTPHeaderField: "Music-User-Token")
+
+            let (data, _) = try await urlSession.data(for: request)
+            let response = try JSONDecoder().decode(AMPlaylistsResponse.self, from: data)
+            self.playlists = response.data
+        } catch {
+            print("🚨 Could not fetch Apple Music playlists: \(error)")
+        }
+    }
+}
+

--- a/amtransfer/AM/Views/AMLibraryView.swift
+++ b/amtransfer/AM/Views/AMLibraryView.swift
@@ -2,41 +2,56 @@ import SwiftUI
 
 struct AMLibraryView: View {
 
-    /// Mock playlists representing existing user content.
-    private let mockPlaylists = [
-        AMPlaylist(id: "m1", name: "Favourites"),
-        AMPlaylist(id: "m2", name: "Road Trip")
-    ]
+    /// Adapter responsible for interacting with Apple Music APIs.
+    @StateObject private var music = AMAdapter()
 
     /// Playlists selected from the Spotify logged in view.
     let selectedPlaylists: [AMPlaylist]
 
     var body: some View {
-        List {
-            Section("My Playlists") {
-                ForEach(mockPlaylists) { playlist in
-                    Text(playlist.name)
-                }
-            }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("My Playlists")
+                        .font(.headline)
 
-            Section("Selected Playlists") {
-                if selectedPlaylists.isEmpty {
-                    Text("No playlists selected")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(selectedPlaylists) { playlist in
-                        Text(playlist.name)
+                    if music.playlists.isEmpty {
+                        ProgressView()
+                    } else {
+                        ForEach(music.playlists) { playlist in
+                            Text(playlist.name)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Selected Playlists")
+                        .font(.headline)
+
+                    if selectedPlaylists.isEmpty {
+                        Text("No playlists selected")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(selectedPlaylists) { playlist in
+                            Text(playlist.name)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
                 }
             }
+            .padding()
+            .padding(.top, 8)
         }
-        .padding(.top, 8)
         .navigationTitle("Library")
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .navigation) {
                 BackButton()
             }
+        }
+        .task {
+            await music.setup()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `AMAdapter` to load Apple Music user playlists via the Music API
- Replace mock data with real playlists in `AMLibraryView` and wrap content in a scroll view

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4066c6bc8325abca41daef1212c7