### PR TITLE
Fetch Apple Music playlists with MusicKit

### DIFF
--- a/amtransfer/AM/AMAdapter.swift
+++ b/amtransfer/AM/AMAdapter.swift
@@ -1,0 +1,30 @@
+import Foundation
+import MusicKit
+
+@MainActor
+class AMAdapter: ObservableObject {
+    @Published var playlists: [AMPlaylist] = []
+    @Published var authorizationStatus: MusicAuthorization.Status = .notDetermined
+
+    /// Requests MusicKit authorization and loads the user's library playlists
+    func setup() async {
+        let status = await MusicAuthorization.request()
+        authorizationStatus = status
+        guard status == .authorized else {
+            return
+        }
+        await loadPlaylists()
+    }
+
+    /// Fetches the user's Apple Music library playlists
+    private func loadPlaylists() async {
+        do {
+            var request = MusicLibraryRequest<Playlist>()
+            request.limit = 100
+            let response = try await request.response()
+            playlists = response.items.map { AMPlaylist(id: $0.id.rawValue, name: $0.name) }
+        } catch {
+            print("🚨 Could not load Apple Music playlists: \(error)")
+        }
+    }
+}

--- a/amtransfer/AM/Views/AMLibraryView.swift
+++ b/amtransfer/AM/Views/AMLibraryView.swift
@@ -1,12 +1,9 @@
 import SwiftUI
+import MusicKit
 
 struct AMLibraryView: View {
 
-    /// Mock playlists representing existing user content.
-    private let mockPlaylists = [
-        AMPlaylist(id: "m1", name: "Favourites"),
-        AMPlaylist(id: "m2", name: "Road Trip")
-    ]
+    @StateObject private var adapter = AMAdapter()
 
     /// Playlists selected from the Spotify logged in view.
     let selectedPlaylists: [AMPlaylist]
@@ -14,8 +11,17 @@ struct AMLibraryView: View {
     var body: some View {
         List {
             Section("My Playlists") {
-                ForEach(mockPlaylists) { playlist in
-                    Text(playlist.name)
+                if adapter.playlists.isEmpty {
+                    if adapter.authorizationStatus == .authorized {
+                        ProgressView()
+                    } else {
+                        Text("Authorize Apple Music to view playlists")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ForEach(adapter.playlists) { playlist in
+                        Text(playlist.name)
+                    }
                 }
             }
 
@@ -37,6 +43,9 @@ struct AMLibraryView: View {
             ToolbarItem(placement: .navigation) {
                 BackButton()
             }
+        }
+        .task {
+            await adapter.setup()
         }
     }
 }


### PR DESCRIPTION
## Summary
- load real Apple Music library playlists using MusicKit
- request MusicKit authorization automatically instead of relying on Secrets.plist

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb63bc4fe48325a051beeb5ebedfa8