### PR TITLE
Add transfer action for selected playlists

### DIFF
--- a/amtransfer/AM/Views/AMLibraryView.swift
+++ b/amtransfer/AM/Views/AMLibraryView.swift
@@ -3,9 +3,15 @@ import MusicKit
 
 struct AMLibraryView: View {
 
+    /// Provides access to the user's Spotify data for fetching tracks.
+    @ObservedObject var spotify: SpotifyAdapter
+
     /// Playlists from the user's Apple Music library.
     @State private var libraryPlaylists: [AMPlaylist] = []
     @State private var isLoading = true
+
+    /// Indicates that a transfer is currently running.
+    @State private var isTransferring = false
 
     /// Playlists selected from the Spotify logged in view.
     let selectedPlaylists: [AMPlaylist]
@@ -43,6 +49,12 @@ struct AMLibraryView: View {
             ToolbarItem(placement: .navigation) {
                 BackButton()
             }
+            ToolbarItem(placement: .primaryAction) {
+                Button("Transfer") {
+                    Task { await transferSelectedPlaylists() }
+                }
+                .disabled(selectedPlaylists.isEmpty || isTransferring)
+            }
         }
         .task {
             await loadLibraryPlaylists()
@@ -71,13 +83,60 @@ struct AMLibraryView: View {
             await MainActor.run { isLoading = false }
         }
     }
+
+    /// Transfers the selected Spotify playlists into the user's Apple Music library.
+    private func transferSelectedPlaylists() async {
+        guard !selectedPlaylists.isEmpty else { return }
+
+        isTransferring = true
+        defer { isTransferring = false }
+
+        do {
+            let status = await MusicAuthorization.request()
+            guard status == .authorized else { return }
+
+            for playlist in selectedPlaylists {
+                // Fetch tracks from Spotify for each selected playlist.
+                let tracks = await spotify.getTracks(for: playlist.id)
+
+                // Attempt to match each Spotify track in the Apple Music catalog.
+                var songs: [Song] = []
+                for track in tracks {
+                    let term = "\(track.name) \(track.artistNames)"
+                    var search = MusicCatalogSearchRequest(term: term, types: [Song.self])
+                    search.limit = 1
+                    if let song = try? await search.response().songs.first {
+                        songs.append(song)
+                    }
+                }
+
+                // Create a new playlist and add the matched songs.
+                var creationRequest = PlaylistCreationRequest(
+                    name: playlist.name,
+                    description: "Transferred from Spotify"
+                )
+                if !songs.isEmpty {
+                    creationRequest.add(items: songs)
+                }
+                _ = try await MusicLibrary.shared.createPlaylist(creationRequest)
+            }
+
+            // Refresh the user's library playlists after transfer.
+            await loadLibraryPlaylists()
+        } catch {
+            print("Failed to transfer playlists: \(error)")
+        }
+    }
 }
 
 #Preview {
     NavigationStack {
-        AMLibraryView(selectedPlaylists: [
-            AMPlaylist(id: "1", name: "Chill Vibes"),
-            AMPlaylist(id: "2", name: "Workout Mix")
-        ])
+        AMLibraryView(
+            spotify: SpotifyAdapter(),
+            selectedPlaylists: [
+                AMPlaylist(id: "1", name: "Chill Vibes"),
+                AMPlaylist(id: "2", name: "Workout Mix")
+            ]
+        )
     }
 }

--- a/amtransfer/Spotify/Views/LoggedInView.swift
+++ b/amtransfer/Spotify/Views/LoggedInView.swift
@@ -65,6 +65,7 @@ struct LoggedInView: View {
 
                 NavigationLink("Open Library") {
                     AMLibraryView(
+                        spotify: spotify,
                         selectedPlaylists: selectedPlaylistObjects.map {
                             AMPlaylist(id: $0.id, name: $0.name)
                         }


### PR DESCRIPTION
## Summary
- pass Spotify adapter into AMLibraryView
- allow transferring selected playlists to Apple Music library

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bd08acebb883259c6e961ba02d7cca