### PR TITLE
Add playlist transfer action to AMLibraryView

### DIFF
--- a/amtransfer/Spotify/Views/LoggedInView.swift
+++ b/amtransfer/Spotify/Views/LoggedInView.swift
@@ -65,6 +65,7 @@ struct LoggedInView: View {
 
                 NavigationLink("Open Library") {
                     AMLibraryView(
+                        spotify: spotify,
                         selectedPlaylists: selectedPlaylistObjects.map {
                             AMPlaylist(id: $0.id, name: $0.name)
                         }


### PR DESCRIPTION
## Summary
- pass SpotifyAdapter into the Apple Music library view to access playlist tracks
- create Apple Music playlists from selected Spotify ones and add best matching songs

## Testing
- `swift build` (fails: Could not find Package.swift in this directory or any of its parent directories.)
- `xcodebuild -project amtransfer.xcodeproj -scheme amtransfer build` (fails: command not found: xcodebuild)


------
https://chatgpt.com/codex/tasks/task_e_68bdfc127d1c8325a846c6e66a4f0f63