### PR TITLE
Add playlist transfer action to AMLibraryView

### DIFF
--- a/amtransfer/Spotify/Views/LoggedInView.swift
+++ b/amtransfer/Spotify/Views/LoggedInView.swift
@@ -67,7 +67,8 @@ struct LoggedInView: View {
                     AMLibraryView(
                         selectedPlaylists: selectedPlaylistObjects.map {
                             AMPlaylist(id: $0.id, name: $0.name)
-                        }
+                        },
+                        spotify: spotify
                     )
                 }
                 .padding(.vertical)


### PR DESCRIPTION
## Summary
- pass Spotify adapter into the Apple Music library view for transferring playlists
- create Apple Music playlists from selected Spotify playlists and add best-match songs from the Apple Music catalog

## Testing
- `swift build` (fails: Could not find Package.swift)
- `xcodebuild -project amtransfer.xcodeproj -scheme amtransfer build` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bdfc127d1c8325a846c6e66a4f0f63