### PR TITLE
Add Spotify playlist transfer to Apple Music library

### DIFF
--- a/amtransfer/AM/Models/PlaylistCreationRequest.swift
+++ b/amtransfer/AM/Models/PlaylistCreationRequest.swift
@@ -1,0 +1,20 @@
+import MusicKit
+
+/// Minimal wrapper to create a playlist in the user's Apple Music library.
+///
+/// The official MusicKit `PlaylistCreationRequest` type is only available
+/// on newer OS versions. This custom struct provides the same interface so the
+/// app compiles on older SDKs; the actual implementation should be filled in
+/// with the necessary network calls when running on a supported platform.
+struct PlaylistCreationRequest {
+    /// Name for the new playlist.
+    var name: String
+
+    /// Tracks to include in the new playlist.
+    var trackIDs: [MusicItemID]
+
+    /// Sends the creation request. Currently a no-op placeholder.
+    func response() async throws {
+        // TODO: Use MusicKit's playlist creation endpoint when available.
+    }
+}

--- a/amtransfer/AM/Models/PlaylistCreationRequest.swift
+++ b/amtransfer/AM/Models/PlaylistCreationRequest.swift
@@ -1,4 +1,5 @@
 import MusicKit
+import Foundation
 
 /// Minimal wrapper to create a playlist in the user's Apple Music library.
 ///
@@ -13,8 +14,30 @@ struct PlaylistCreationRequest {
     /// Tracks to include in the new playlist.
     var trackIDs: [MusicItemID]
 
-    /// Sends the creation request. Currently a no-op placeholder.
+    /// Sends the playlist creation request to Apple Music.
+    ///
+    /// This implementation uses ``MusicDataRequest`` to call the
+    /// `me/library/playlists` endpoint and create the playlist with the
+    /// supplied tracks.
     func response() async throws {
-        // TODO: Use MusicKit's playlist creation endpoint when available.
+        let url = URL(string: "https://api.music.apple.com/v1/me/library/playlists")!
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "attributes": ["name": name],
+            "relationships": [
+                "tracks": [
+                    "data": trackIDs.map { ["id": $0.rawValue, "type": "songs"] }
+                ]
+            ]
+        ]
+
+        urlRequest.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        var request = MusicDataRequest(urlRequest: urlRequest)
+        request.requiresMusicUserToken = true
+        _ = try await request.response()
     }
 }

--- a/amtransfer/AM/Views/AMLibraryView.swift
+++ b/amtransfer/AM/Views/AMLibraryView.swift
@@ -3,42 +3,71 @@ import MusicKit
 
 struct AMLibraryView: View {
 
+    /// Adapter used to fetch tracks from Spotify playlists.
+    @ObservedObject var spotify: SpotifyAdapter
+
     /// Playlists from the user's Apple Music library.
     @State private var libraryPlaylists: [AMPlaylist] = []
     @State private var isLoading = true
     @State private var errorMessage: String? = nil
 
+    /// Indicates whether a transfer operation is currently running.
+    @State private var isTransferring = false
+
+    /// Message shown after a transfer completes or fails.
+    @State private var transferMessage: String? = nil
+
     /// Playlists selected from the Spotify logged in view.
     let selectedPlaylists: [AMPlaylist]
 
     var body: some View {
-        List {
-            Section("My Playlists") {
-                if isLoading {
-                    ProgressView()
-                } else if let errorMessage {
-                    Text(errorMessage)
-                        .foregroundStyle(.red)
-                } else if libraryPlaylists.isEmpty {
-                    Text("No playlists in library")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(libraryPlaylists) { playlist in
-                        Text(playlist.name)
+        VStack {
+            List {
+                Section("My Playlists") {
+                    if isLoading {
+                        ProgressView()
+                    } else if let errorMessage {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    } else if libraryPlaylists.isEmpty {
+                        Text("No playlists in library")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(libraryPlaylists) { playlist in
+                            Text(playlist.name)
+                        }
+                    }
+                }
+
+                Section("Selected Playlists") {
+                    if selectedPlaylists.isEmpty {
+                        Text("No playlists selected")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(selectedPlaylists) { playlist in
+                            Text(playlist.name)
+                        }
                     }
                 }
             }
 
-            Section("Selected Playlists") {
-                if selectedPlaylists.isEmpty {
-                    Text("No playlists selected")
-                        .foregroundStyle(.secondary)
-                } else {
-                    ForEach(selectedPlaylists) { playlist in
-                        Text(playlist.name)
-                    }
+            if isTransferring {
+                ProgressView("Transferring...")
+                    .padding(.vertical)
+            }
+
+            if let transferMessage {
+                Text(transferMessage)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button("Transfer Selected Playlists") {
+                Task {
+                    await transferSelectedPlaylists()
                 }
             }
+            .disabled(isTransferring || selectedPlaylists.isEmpty)
+            .padding(.vertical)
         }
         .padding(.top, 8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -91,13 +120,60 @@ struct AMLibraryView: View {
             }
         }
     }
+
+    /// Transfers the selected Spotify playlists into the user's Apple Music library.
+    /// Each Spotify playlist is matched track by track using a simple search and
+    /// then recreated as a new playlist in Apple Music.
+    private func transferSelectedPlaylists() async {
+        await MainActor.run {
+            isTransferring = true
+            transferMessage = nil
+        }
+
+        do {
+            for playlist in selectedPlaylists {
+                let tracks = await spotify.getTracks(for: playlist.id)
+                var trackIDs: [MusicItemID] = []
+
+                for track in tracks {
+                    let term = "\(track.name) \(track.artistNames)"
+                    var search = MusicCatalogSearchRequest(term: term, types: [Song.self])
+                    search.limit = 1
+                    let response = try await search.response()
+                    if let song = response.songs.first {
+                        trackIDs.append(song.id)
+                    }
+                }
+
+                if !trackIDs.isEmpty {
+                    var create = PlaylistCreationRequest(name: playlist.name, trackIDs: trackIDs)
+                    _ = try await create.response()
+                }
+            }
+
+            await MainActor.run {
+                transferMessage = "Transfer complete"
+            }
+        } catch {
+            await MainActor.run {
+                transferMessage = "Failed to transfer playlists"
+            }
+        }
+
+        await MainActor.run {
+            isTransferring = false
+        }
+    }
 }
 
 #Preview {
     NavigationStack {
-        AMLibraryView(selectedPlaylists: [
-            AMPlaylist(id: "1", name: "Chill Vibes"),
-            AMPlaylist(id: "2", name: "Workout Mix")
-        ])
+        AMLibraryView(
+            spotify: SpotifyAdapter(),
+            selectedPlaylists: [
+                AMPlaylist(id: "1", name: "Chill Vibes"),
+                AMPlaylist(id: "2", name: "Workout Mix")
+            ]
+        )
     }
 }

--- a/amtransfer/Spotify/Views/LoggedInView.swift
+++ b/amtransfer/Spotify/Views/LoggedInView.swift
@@ -66,6 +66,7 @@ struct LoggedInView: View {
 
                 NavigationLink("Open Library") {
                     AMLibraryView(
+                        spotify: spotify,
                         selectedPlaylists: selectedPlaylistObjects.map {
                             AMPlaylist(id: $0.id, name: $0.name)
                         }

--- a/amtransfer/amtransfer.entitlements
+++ b/amtransfer/amtransfer.entitlements
@@ -6,7 +6,15 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.developer.music.subscription-service</key>
+    <true/>
+    <key>com.apple.developer.music-user-token</key>
+    <string></string>
+    <key>com.apple.security.exception.mach-lookup.global-name</key>
+    <array>
+        <string>com.apple.itunescloud.music-subscription-status-service</string>
+    </array>
 </dict>
 </plist>

--- a/amtransferTests/ViewLayoutTests.swift
+++ b/amtransferTests/ViewLayoutTests.swift
@@ -28,6 +28,6 @@ struct ViewLayoutTests {
     }
 
     @Test func amLibraryViewFillsScreen() {
-        assertFillsScreen(AMLibraryView(selectedPlaylists: []))
+        assertFillsScreen(AMLibraryView(spotify: SpotifyAdapter(), selectedPlaylists: []))
     }
 }


### PR DESCRIPTION
## Summary
- add transfer button and logic to recreate selected Spotify playlists in Apple Music
- pass Spotify adapter into library view to enable fetching tracks for transfer
- update view layout test for new library view signature

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*
- `xcodebuild test -scheme amtransfer -project amtransfer.xcodeproj` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f6220520832597bdce323f61dcb8